### PR TITLE
Add flush to example

### DIFF
--- a/example/src/example/lambda.clj
+++ b/example/src/example/lambda.clj
@@ -11,5 +11,7 @@
 (deflambdafn example.lambda.MyLambdaFn
   [in out ctx]
   (let [event (json/read (io/reader in))
-        res (handle-event event)]
-    (json/write res (io/writer out))))
+        res (handle-event event)
+        w (io/writer out)]
+    (json/write res w)
+    (.flush w)))


### PR DESCRIPTION
I had to flush to get the {:status "ok"} result to be returned. Saw this line on the AWS blog "Writing AWS Lambda Functions in Clojure": https://aws.amazon.com/blogs/compute/clojure/

Thanks!
